### PR TITLE
fixes #1 output parameter crash by importing os

### DIFF
--- a/scripts/rosbag_image_compressor
+++ b/scripts/rosbag_image_compressor
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import os
 from rosbag_image_compressor import compress_image,\
     uncompress_image, compress, uncompress
 


### PR DESCRIPTION
output parameter can now be omitted safely with no crashing
