### PR TITLE
uses message type instead of topic name

### DIFF
--- a/test/test_rosbag_image_compressor.py
+++ b/test/test_rosbag_image_compressor.py
@@ -116,11 +116,11 @@ class TestClass(unittest.TestCase):
             with rosbag.Bag(intermediate, 'r') as bag:
                 for topic, msg, t in bag:
                     # non-standard topic name should have flag in encoding
-                    if topic == '/foo':
-                        self.assertTrue(msg.encoding.endswith(', no-basename'))
+                    if topic == '/foo/encoding':
+                        self.assertTrue(str(msg).endswith(', no-basename'))
                     # standard topic name should not have flag in encoding
-                    elif topic == 'foo/bar/image_raw':
-                        self.assertFalse(msg.encoding.endswith(', no-basename'))
+                    elif topic == '/foo/bar/encoding':
+                        self.assertFalse(str(msg).endswith(', no-basename'))
             # run uncompress on bag
             uncompress(intermediate, output)
 
@@ -128,3 +128,4 @@ class TestClass(unittest.TestCase):
             with rosbag.Bag(output, 'r') as bag:
                 for topic, msg, t in bag:
                     self.check_contents(create_image_msg(), msg)
+                    self.assertFalse(msg.encoding.endswith(', no-basename'))


### PR DESCRIPTION
Instead of using the topic name for choosing messages to compress/decompress, it checks whether the message types are `sensor_msgs/Image` or `sensor_msgs/CompressedImage`.

I also had to modify the `image_topic_basename()` function to return None instead of raise an exception. In the case that it can't find a basename, the script just uses the old topic name and compresses/decompresses if the message types match.

I ran this through the unittest in the package, and it checked out out fine. I also ran it manually, and it seemed ok. Let me know if it's too hacky, maybe I can think of something better.
